### PR TITLE
Reorder SchemeStatus input fields

### DIFF
--- a/src/views/SchemeNameAndAddress.tsx
+++ b/src/views/SchemeNameAndAddress.tsx
@@ -105,7 +105,7 @@ const SchemeNameAndAddress = () => {
                   cfg={{
                     mb: 4,
                     p: 3,
-                    bg: 'neutral.1',
+                    bg: 'neutral.3',
                     flexDirection: 'row',
                   }}
                 >

--- a/src/views/SchemeStatusAndMembership.tsx
+++ b/src/views/SchemeStatusAndMembership.tsx
@@ -24,10 +24,9 @@ const SchemeStatusAndMembership = () => {
     {
       name: RADIO_BUTTON_NAME,
       type: 'radio',
-      label: 'Paid up (frozen)',
-      hint:
-        "No more contributions are due to be paid into the scheme. Existing members' benefits are still held in the scheme.",
-      value: 'paid',
+      label: 'Open to new members',
+      value: 'open',
+      cfg: { mt: 1, mb: 3 },
     },
     {
       name: RADIO_BUTTON_NAME,
@@ -39,9 +38,10 @@ const SchemeStatusAndMembership = () => {
     {
       name: RADIO_BUTTON_NAME,
       type: 'radio',
-      label: 'Open to new members',
-      value: 'open',
-      cfg: { mt: 1, mb: 3 },
+      label: 'Paid up (frozen)',
+      hint:
+        "No more contributions are due to be paid into the scheme. Existing members' benefits are still held in the scheme.",
+      value: 'paid',
     },
     {
       name: RADIO_BUTTON_NAME,
@@ -70,7 +70,7 @@ const SchemeStatusAndMembership = () => {
         }
       },
       inputWidth: 1,
-      cfg: { mb: 3 },
+      cfg: { mb: 5 },
       required: true,
     },
     {
@@ -87,7 +87,7 @@ const SchemeStatusAndMembership = () => {
         }
       },
       inputWidth: 1,
-      cfg: { mb: 3 },
+      cfg: { mb: 5 },
       required: true,
     },
     {
@@ -103,7 +103,7 @@ const SchemeStatusAndMembership = () => {
         }
       },
       inputWidth: 1,
-      cfg: { mb: 3 },
+      cfg: { mb: 5 },
       required: true,
     },
     {
@@ -120,7 +120,7 @@ const SchemeStatusAndMembership = () => {
         }
       },
       inputWidth: 1,
-      cfg: { mb: 3 },
+      cfg: { mb: 5 },
       required: true,
     },
   ];
@@ -150,7 +150,7 @@ const SchemeStatusAndMembership = () => {
         </Link>
         <H1 cfg={{ mb: 2 }}>Scheme status and membership</H1>
         <Hr cfg={{ mt: 6, mb: 8 }} />
-        <P cfg={{ mb: 4 }}>
+        <P cfg={{ mb: 6 }}>
           These are the scheme details currently held by the regulator. Correct
           any details as necessary.
         </P>

--- a/src/views/SchemeStatusAndMembership.tsx
+++ b/src/views/SchemeStatusAndMembership.tsx
@@ -169,11 +169,11 @@ const SchemeStatusAndMembership = () => {
         >
           {({ handleSubmit }) => (
             <form onSubmit={handleSubmit}>
-              <H4 cfg={{ mb: 2 }}>Scheme status</H4>
+              <H4 cfg={{ mb: 6 }}>Scheme status</H4>
               <SeparatorY>
                 <div>{renderFields(SchemeStatusFields)}</div>
               </SeparatorY>
-              <Flex cfg={{ bg: 'neutral.1', p: 6 }}>
+              <Flex cfg={{ bg: 'neutral.3', p: 6 }}>
                 <FFInputDate
                   name="schemeStatusApplied"
                   label="Date scheme status applied"
@@ -189,10 +189,10 @@ const SchemeStatusAndMembership = () => {
                 />
               </Flex>
 
-              <H4 cfg={{ mb: 2 }}>Scheme Membership</H4>
-              <P cfg={{ mb: 2 }}>Tell us the number of:</P>
+              <H4 cfg={{ mt: 4, mb: 4 }}>Scheme Membership</H4>
+              <P cfg={{ mb: 3 }}>Tell us the number of:</P>
               <div>{renderFields(SchemeMembershipFields)}</div>
-              <Flex cfg={{ bg: 'neutral.1', p: 6 }}>
+              <Flex cfg={{ bg: 'neutral.3', p: 6 }}>
                 <FFInputDate
                   name="dateMembershipEffective"
                   label="Date membership became effective"

--- a/src/views/Trustees.tsx
+++ b/src/views/Trustees.tsx
@@ -44,7 +44,7 @@ const Trustees = () => {
           The following is a list of the trustees we hold for the scheme. It is
           important that our records match the scheme records.
         </P>
-        <Flex cfg={{ p: 4, bg: 'neutral.1', justifyContent: 'space-between' }}>
+        <Flex cfg={{ p: 4, bg: 'neutral.3', justifyContent: 'space-between' }}>
           <P>Total Number of Trustees: {trustees.length}</P>
           <AddTrusteeLink />
         </Flex>


### PR DESCRIPTION
For [Task 59693: Reorder 'scheme status' elements inline with the prototype](https://dev.azure.com/thepensionsregulator/TPR/_sprints/taskboard/PortalTeam/TPR/PI%202-0/Sprint%2022?workitem=59693)

Focus on:
- Updated background colors of Date input and flex boxes to reflect colors shown in prototype
- Reordered scheme status field elements to reflect order shown in prototype