### PR TITLE
Enable save and continue if all 'all details correct' boxes checked

### DIFF
--- a/src/views/Trustees.tsx
+++ b/src/views/Trustees.tsx
@@ -57,7 +57,13 @@ const Trustees = () => {
             onContactSave={updateTrustee}
             onAddressSave={updateTrustee}
             onRemove={removeTrustee}
-            onCorrect={(value: any) => setComplete(value)}
+            onCorrect={(value: any) => {
+              if (value) {
+                setCorrectTrusteeDetails(correctTrusteeDetails + 1);
+              } else {
+                setCorrectTrusteeDetails(correctTrusteeDetails - 1);
+              }
+            }}
             addressAPI={{
               get: (endpoint: any) => callAddressAPI(endpoint),
               limit: 100,

--- a/src/views/Trustees.tsx
+++ b/src/views/Trustees.tsx
@@ -10,12 +10,13 @@ import ScrollToTop from '../components/ScrollToTop';
 import TrusteeRepository from '../services/TrusteeRepository';
 import { TrusteeProps } from '@tpr/layout/lib/components/cards/trustee/trusteeMachine';
 const Trustees = () => {
-  const submit = () => {
+  const onSubmit = (values: any) => {
     console.log('Submitting form');
   };
 
-  const [complete, setComplete] = useState(false);
+  const [complete] = useState(false);
   const [trustees, setTrustees] = useState(TrusteeRepository.GetAllTrustees());
+  const [correctTrusteeDetails, setCorrectTrusteeDetails] = useState(0);
 
   const callAddressAPI = (a: any) => {
     console.log('Calling an address API...');

--- a/src/views/Trustees.tsx
+++ b/src/views/Trustees.tsx
@@ -88,7 +88,7 @@ const Trustees = () => {
           <AddTrusteeLink />
         </Flex>
         <Hr cfg={{ mb: 8 }} />
-        <Form onSubmit={submit}>
+        <Form onSubmit={onSubmit}>
           {({ handleSubmit }) => (
             <form onSubmit={handleSubmit}>
               <ArrowButton

--- a/src/views/Trustees.tsx
+++ b/src/views/Trustees.tsx
@@ -14,7 +14,7 @@ const Trustees = () => {
     console.log('Submitting form');
   };
 
-  const [complete] = useState(false);
+  const complete = false;
   const [trustees, setTrustees] = useState(TrusteeRepository.GetAllTrustees());
   const [correctTrusteeDetails, setCorrectTrusteeDetails] = useState(0);
 

--- a/src/views/Trustees.tsx
+++ b/src/views/Trustees.tsx
@@ -18,32 +18,9 @@ const Trustees = () => {
   const [trustees, setTrustees] = useState(TrusteeRepository.GetAllTrustees());
   const [correctTrusteeDetails, setCorrectTrusteeDetails] = useState(0);
 
-<<<<<<< HEAD
   const callAddressAPI = (a: any) => {
     console.log('Calling an address API...');
     return Promise.resolve();
-=======
-  const callAddressAPI = (endpoint: string) => {
-    const results = Promise.resolve({
-      data: {
-        results: [
-          {
-            format: 'https://SomeFakeApi124a.dev/v2/someFakeEndpoint1',
-          },
-        ],
-        address: [
-          { addressLine1: 'The Pensions Regulator' },
-          { addressLine2: 'Napier House' },
-          { addressLine3: 'Trafalgar Place' },
-          { locality: 'Brighton' },
-          { province: 'East Sussex' },
-          { postalCode: 'BN1 4DW' },
-          { country: '' },
-        ],
-      },
-    });
-    return results;
->>>>>>> 851bc335320b83a38f71768dd01dfbd90545a75e
   };
 
   const removeTrustee = (formValues: any, trusteeToRemove: TrusteeInput) => {

--- a/src/views/Trustees.tsx
+++ b/src/views/Trustees.tsx
@@ -96,6 +96,7 @@ const Trustees = () => {
                 pointsTo="right"
                 iconSide="right"
                 title="Save and Continue"
+                disabled={!(correctTrusteeDetails === trustees.length)}
               />
             </form>
           )}

--- a/src/views/Trustees.tsx
+++ b/src/views/Trustees.tsx
@@ -20,7 +20,9 @@ const Trustees = () => {
 
   const callAddressAPI = (a: any) => {
     console.log('Calling an address API...');
-    return Promise.resolve();
+    console.log(a);
+
+    return Promise.resolve({ results: { addressLine1: '2 Cromwell' } });
   };
 
   const removeTrustee = (formValues: any, trusteeToRemove: TrusteeInput) => {
@@ -57,7 +59,7 @@ const Trustees = () => {
             onContactSave={updateTrustee}
             onAddressSave={updateTrustee}
             onRemove={removeTrustee}
-            onCorrect={(value: any) => {
+            onCorrect={(value: boolean) => {
               if (value) {
                 setCorrectTrusteeDetails(correctTrusteeDetails + 1);
               } else {

--- a/src/views/Trustees.tsx
+++ b/src/views/Trustees.tsx
@@ -14,15 +14,13 @@ const Trustees = () => {
     console.log('Submitting form');
   };
 
-  const complete = false;
+  const complete = false; // Will need to be changed to useState(false) to implement the 'correct' functionality
   const [trustees, setTrustees] = useState(TrusteeRepository.GetAllTrustees());
   const [correctTrusteeDetails, setCorrectTrusteeDetails] = useState(0);
 
   const callAddressAPI = (a: any) => {
     console.log('Calling an address API...');
-    console.log(a);
-
-    return Promise.resolve({ results: { addressLine1: '2 Cromwell' } });
+    return Promise.resolve();
   };
 
   const removeTrustee = (formValues: any, trusteeToRemove: TrusteeInput) => {

--- a/src/views/Trustees.tsx
+++ b/src/views/Trustees.tsx
@@ -18,11 +18,26 @@ const Trustees = () => {
   const [trustees, setTrustees] = useState(TrusteeRepository.GetAllTrustees());
   const [correctTrusteeDetails, setCorrectTrusteeDetails] = useState(0);
 
-  const callAddressAPI = (a: any) => {
-    console.log('Calling an address API...');
-    console.log(a);
-
-    return Promise.resolve({ results: { addressLine1: '2 Cromwell' } });
+  const callAddressAPI = (endpoint: string) => {
+    const results = Promise.resolve({
+      data: {
+        results: [
+          {
+            format: 'https://SomeFakeApi124a.dev/v2/someFakeEndpoint1',
+          },
+        ],
+        address: [
+          { addressLine1: 'The Pensions Regulator' },
+          { addressLine2: 'Napier House' },
+          { addressLine3: 'Trafalgar Place' },
+          { locality: 'Brighton' },
+          { province: 'East Sussex' },
+          { postalCode: 'BN1 4DW' },
+          { country: '' },
+        ],
+      },
+    });
+    return results;
   };
 
   const removeTrustee = (formValues: any, trusteeToRemove: TrusteeInput) => {


### PR DESCRIPTION
For [Task 59660: Disable 'Save and continue' until all 'all details are correct' is checked](https://dev.azure.com/thepensionsregulator/TPR/_sprints/taskboard/PortalTeam/TPR/PI%202-0/Sprint%2022?workitem=59660)

Focus on:
- Clicking the checkbox in a trustee card should increase the value of `correctTrusteeDetails`
- Clicking the checkbox again in a trustee card should decrease the value of `correctTrusteeDetails`
- 'Save and continue' should only be enabled if the value of `correctTrusteeDetails` is the same as the number of trustee cards on the page.

Thanks @bentpr for the help! 