### PR TITLE
Feature/add query strings

### DIFF
--- a/src/views/AddIndividualTrustee/IndividualTrusteeStepFour.tsx
+++ b/src/views/AddIndividualTrustee/IndividualTrusteeStepFour.tsx
@@ -40,7 +40,7 @@ const IndividualTrusteeStepFour = (props: any) => {
   const onSubmit = (values: any) => {
     TrusteeRepository.WriteTrustee({ ...props.newTrustee, ...values });
     console.log('trustee added');
-    history.push({ pathname: '/trustees', search: 'state=trustee_added' });
+    history.push({ pathname: '/trustees', search: 'state=trustee-added' });
   };
 
   return (

--- a/src/views/AddIndividualTrustee/IndividualTrusteeStepFour.tsx
+++ b/src/views/AddIndividualTrustee/IndividualTrusteeStepFour.tsx
@@ -39,7 +39,8 @@ const IndividualTrusteeStepFour = (props: any) => {
 
   const onSubmit = (values: any) => {
     TrusteeRepository.WriteTrustee({ ...props.newTrustee, ...values });
-    history.push('/trustees');
+    console.log('trustee added');
+    history.push({ pathname: '/trustees', search: 'state=trustee_added' });
   };
 
   return (

--- a/src/views/Trustees.tsx
+++ b/src/views/Trustees.tsx
@@ -56,6 +56,12 @@ const Trustees = () => {
     return Promise.resolve();
   };
 
+  const updateDetails = (formValues: any, trusteeToUpdate: TrusteeProps) => {
+    const result = updateTrustee(formValues, trusteeToUpdate);
+    history.push({ search: 'state=trustee-details-edit' });
+    return result;
+  };
+
   return (
     <div className={Styles.root}>
       <UserResearchSidebar />
@@ -74,7 +80,7 @@ const Trustees = () => {
         {trustees.map((trustee) => (
           <TrusteeCard
             key={trustee.schemeRoleId.toString()}
-            onDetailsSave={updateTrustee}
+            onDetailsSave={updateDetails}
             onContactSave={updateTrustee}
             onAddressSave={updateTrustee}
             onRemove={removeTrustee}

--- a/src/views/Trustees.tsx
+++ b/src/views/Trustees.tsx
@@ -62,6 +62,12 @@ const Trustees = () => {
     return result;
   };
 
+  const updateContact = (formValues: any, trusteeToUpdate: TrusteeProps) => {
+    const result = updateTrustee(formValues, trusteeToUpdate);
+    history.push({ search: 'state=trustee-contacts-edit' });
+    return result;
+  };
+
   return (
     <div className={Styles.root}>
       <UserResearchSidebar />
@@ -81,7 +87,7 @@ const Trustees = () => {
           <TrusteeCard
             key={trustee.schemeRoleId.toString()}
             onDetailsSave={updateDetails}
-            onContactSave={updateTrustee}
+            onContactSave={updateContact}
             onAddressSave={updateTrustee}
             onRemove={removeTrustee}
             onCorrect={(value: boolean) => {

--- a/src/views/Trustees.tsx
+++ b/src/views/Trustees.tsx
@@ -68,6 +68,12 @@ const Trustees = () => {
     return result;
   };
 
+  const updateAddress = (formValues: any, trusteeToUpdate: TrusteeProps) => {
+    const result = updateTrustee(formValues, trusteeToUpdate);
+    history.push({ search: 'state=trustee-address-edit' });
+    return result;
+  };
+
   return (
     <div className={Styles.root}>
       <UserResearchSidebar />
@@ -88,7 +94,7 @@ const Trustees = () => {
             key={trustee.schemeRoleId.toString()}
             onDetailsSave={updateDetails}
             onContactSave={updateContact}
-            onAddressSave={updateTrustee}
+            onAddressSave={updateAddress}
             onRemove={removeTrustee}
             onCorrect={(value: boolean) => {
               if (value) {

--- a/src/views/Trustees.tsx
+++ b/src/views/Trustees.tsx
@@ -9,10 +9,13 @@ import { Form } from '@tpr/forms';
 import ScrollToTop from '../components/ScrollToTop';
 import TrusteeRepository from '../services/TrusteeRepository';
 import { TrusteeProps } from '@tpr/layout/lib/components/cards/trustee/trusteeMachine';
+import { useHistory } from 'react-router-dom';
 const Trustees = () => {
   const onSubmit = (values: any) => {
     console.log('Submitting form');
   };
+
+  const history = useHistory();
 
   const complete = false; // Will need to be changed to useState(false) to implement the 'correct' functionality
   const [trustees, setTrustees] = useState(TrusteeRepository.GetAllTrustees());
@@ -43,6 +46,7 @@ const Trustees = () => {
   const removeTrustee = (formValues: any, trusteeToRemove: TrusteeInput) => {
     TrusteeRepository.RemoveTrustee(trusteeToRemove);
     setTrustees([...TrusteeRepository.GetAllTrustees()]);
+    history.push({ search: 'state=trustee-removed' });
     return Promise.resolve();
   };
 


### PR DESCRIPTION
For [Task 59802: Add search query on to the end of the URL after a user has successfully edited, removed and created a trustee](https://dev.azure.com/thepensionsregulator/TPR/_sprints/taskboard/PortalTeam/TPR/PI%202-0/Sprint%2022?workitem=59802)

Focus on:
- search query is changed after one of the following actions is completed:
 - add a trustee
 - removed a trustee
 - edit a trustee address
 - edit a trustee contact details
 - edit a trustee name & type